### PR TITLE
Update tint of resource icons of third party QS tiles

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/qs/QSTile.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/QSTile.java
@@ -493,15 +493,18 @@ public abstract class QSTile<TState extends State> {
 
     public static class DrawableIconWithRes extends DrawableIcon {
         private final int mId;
+        private final int mColor;
 
-        public DrawableIconWithRes(Drawable drawable, int id) {
+        public DrawableIconWithRes(Drawable drawable, int id, int color) {
             super(drawable);
             mId = id;
+            mColor = color;
         }
 
         @Override
         public boolean equals(Object o) {
-            return o instanceof DrawableIconWithRes && ((DrawableIconWithRes) o).mId == mId;
+            return o instanceof DrawableIconWithRes && ((DrawableIconWithRes) o).mId == mId &&
+                    ((DrawableIconWithRes) o).mColor == mColor;
         }
     }
 

--- a/packages/SystemUI/src/com/android/systemui/qs/external/CustomTile.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/external/CustomTile.java
@@ -302,8 +302,8 @@ public class CustomTile extends QSTile<QSTile.State> implements TileChangeListen
         }
         int color = mContext.getColor(getColor(tileState));
         drawable.setTint(color);
-        state.icon = mHasRes ? new DrawableIconWithRes(drawable, icon.getResId())
-                : new DrawableIcon(drawable);
+        state.icon = mHasRes ? new DrawableIconWithRes(
+                drawable, icon.getResId(), color) : new DrawableIcon(drawable);
         state.label = mTile.getLabel();
         if (tileState == Tile.STATE_UNAVAILABLE) {
             state.label = new SpannableStringBuilder().append(state.label,


### PR DESCRIPTION
Since commit d2274f848c586d86404ae14dfb8d11a02ee4867a
("Fix animations for app QS tiles."), the tint of resource icons of
third party tiles doesn't change when the tile status changes. Keep
track of the tint so that changing the status of the icon will cause
an update of the icon.

BUGBASH-1239

Change-Id: Ib2a91a00b6912ae85f37dd096e62bb6b979e9fc7